### PR TITLE
Clean up truffle box commands and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First ensure you are in a new and empty directory.
     truffle unbox rsksmart/rsk-next-box
     ```
 
-3. Install dependencies and Run the development console.
+3. Install dependencies and run the development console.
     ```javascript
     yarn    # alternatively `npm install`
     truffle develop

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For more information about the **Gas** and **minimumGasPrice** please go [here](
     # Console for Mainnet
     truffle console --network mainnet
 
-    # Console forn Testnet
+    # Console for Testnet
     truffle console --network testnet
     ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First ensure you are in a new and empty directory.
 
 3. Install dependencies and Run the development console.
     ```javascript
-    yarn
+    yarn    # alternatively `npm install`
     truffle develop
     ```
 
@@ -33,7 +33,7 @@ First ensure you are in a new and empty directory.
     ```javascript
     // in another terminal (i.e. not in the truffle develop prompt)
     cd app
-    npm run dev
+    yarn run dev   # alternatively `npm start dev`
     ```
 
 6. Truffle can run tests written in Solidity or JavaScript against your smart contracts. Note the command varies slightly if you're in or outside of the development console.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ First ensure you are in a new and empty directory.
     truffle unbox rsksmart/rsk-next-box
     ```
 
-3. Run the development console.
+3. Install dependencies and Run the development console.
     ```javascript
+    yarn
     truffle develop
     ```
 

--- a/truffle-box.json
+++ b/truffle-box.json
@@ -7,10 +7,10 @@
     "Compile contracts": "truffle compile",
     "Migrate contracts": "truffle migrate",
     "Test contracts": "truffle test",
-    "Run dev server": "cd app && yarn start",
+    "Run dev server": "cd app && yarn run dev",
     "Build for production": "cd app && yarn build"
   },
   "hooks": {
-    "post-unpack": "npm install && npm install -g yarn && cd app/ && yarn"
+    "post-unpack": "yarn && cd app && yarn"
   }
 }


### PR DESCRIPTION
This PR adds a couple of changes

truffle-box.json:
  - not install yarn globally. it is bad practice to overwrite global modules.
  - update incorrect yarn command in command/messages

Readme
  - add yarn command in readme to cover case user may not have it installed
  - add npm alternative for yarn command
  - fix a typo
     
 